### PR TITLE
Testing a lack of sign-off

### DIFF
--- a/DO_NOT_ACCEPT_THIS_PR
+++ b/DO_NOT_ACCEPT_THIS_PR
@@ -1,0 +1,1 @@
+Just testing


### PR DESCRIPTION
This is a test PR that the DCO checker should reject if a signoff is missing.