### PR TITLE
Allow passing options to docker-compose pull

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased][]
 
+### Added
+
+- Docket can pass options to `docker-compose pull` if you set
+  `DOCKET_PULL_OPTS`.
+
 ## [0.3.0][] ([diff][0.3.0-diff]) - 2019-05-15
 
 ### Changed

--- a/README.markdown
+++ b/README.markdown
@@ -85,6 +85,19 @@ _Default:_ `false`
 If `DOCKET_PULL` is non-empty, docket will run `docker-compose pull` at the
 start of each `docket.Run()`.
 
+#### DOCKET_PULL_OPTS
+
+_Default:_ ``
+
+If `DOCKET_PULL_OPTS` is non-empty, docket will add its contents to the
+invocation of the `docker-compose pull` command.
+
+For example, to avoid pulling images in parallel, you can set
+`DOCKET_PULL_OPTS=--no-parallel` so that docket will run
+`docker-compose pull --no-parallel`.
+
+Setting `DOCKET_PULL_OPTS` has no effect if you do not set `DOCKET_PULL=1`.
+
 ### Using a custom file prefix
 
 If you need to keep multiple independent docket configurations in the same

--- a/docket.go
+++ b/docket.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/bloomberg/docket/internal/compose"
@@ -100,7 +101,8 @@ func RunPrefix(ctx context.Context, docketCtx *Context, t *testing.T, prefix str
 	}
 
 	if os.Getenv("DOCKET_PULL") != "" {
-		if err := compose.Pull(ctx); err != nil {
+		pullOpts := strings.Fields(os.Getenv("DOCKET_PULL_OPTS"))
+		if err := compose.Pull(ctx, pullOpts); err != nil {
 			t.Fatalf("failed compose.Pull: %v", err)
 		}
 		// } else {

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -137,9 +137,10 @@ func (c Compose) GetPort(ctx context.Context, service string, port int) (int, er
 }
 
 // Pull calls `docker-compose pull`.
-func (c Compose) Pull(ctx context.Context) error {
+func (c Compose) Pull(ctx context.Context, args []string) error {
 	cmd := c.Command(ctx, "pull")
 
+	cmd.Args = append(cmd.Args, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 


### PR DESCRIPTION
This change exposes the --no-parallel option of the docker-compose pull
subcommand in the event the user wishes not to pull images in parallel.

There are cases where users may want to disable the default parallel
pulling of images. A bad network connection, limited bandwidth
throughput, an unreliable storage service, etc. We can't possibly
foresee every use case that one might encounter.

Signed-off-by: Mike Seplowitz <mseplowitz@bloomberg.net>