### PR TITLE
Rename test to allow typing `go test -run help`

### DIFF
--- a/help_test.go
+++ b/help_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func Test_Help(t *testing.T) {
+func Test_help(t *testing.T) {
 	suite.Run(t, &HelpSuite{})
 }
 


### PR DESCRIPTION
Signed-off-by: Mike Seplowitz <mseplowitz@bloomberg.net>