### PR TITLE
Add a few missing error checks

### DIFF
--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -34,7 +34,11 @@ func Test_Compose(t *testing.T) {
 	if err := os.Chdir("testdata"); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chdir(origDir)
+	defer func() {
+		if err := os.Chdir(origDir); err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	suite.Run(t, &ComposeSuite{
 		ctx: context.Background(),

--- a/test_03_redispinger-service_test.go
+++ b/test_03_redispinger-service_test.go
@@ -65,7 +65,7 @@ func (s *RedisPingerSuite) Test_DebugMode() {
 	pingerCmd, pingerPort := s.startPinger(ctx)
 	defer func() {
 		s.Require().NoError(pingerCmd.Process.Kill())
-		pingerCmd.Wait()
+		s.Error(pingerCmd.Wait()) // since we killed the process, Wait will return an error
 	}()
 
 	// Run go test with REDISPINGER_URL set properly


### PR DESCRIPTION
These were found by golangci-lint's standard checks.