### PR TITLE
Context consistency updates

### DIFF
--- a/dkt/runner.go
+++ b/dkt/runner.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -70,7 +71,7 @@ func run(
 	if debugTraceEnabled {
 		fmt.Fprintf(stderr, "%sbuilding %s\n", debugPrefix, actualMainPkg)
 	}
-	dktExePath, err := tempbuild.Build(actualMainPkg, "dkt.")
+	dktExePath, err := tempbuild.Build(context.Background(), actualMainPkg, "dkt.")
 	if err != nil {
 		fmt.Fprintf(stderr, "ERROR: failed to build dkt: %v\n", err)
 		fmt.Fprintf(stderr, "--- diagnostics follow ---\n")

--- a/help_test.go
+++ b/help_test.go
@@ -15,7 +15,6 @@
 package docket_test
 
 import (
-	"context"
 	"os/exec"
 	"testing"
 
@@ -31,7 +30,7 @@ type HelpSuite struct {
 }
 
 func (s *HelpSuite) Test_runGoTest() {
-	cmd := exec.CommandContext(context.Background(), "go", "test", "-help-docket")
+	cmd := exec.Command("go", "test", "-help-docket")
 	cmd.Args = append(cmd.Args, goTestCoverageArgs(s.T().Name())...)
 	cmd.Args = append(cmd.Args, goTestRaceDetectorArgs()...)
 

--- a/internal/tempbuild/tempbuild.go
+++ b/internal/tempbuild/tempbuild.go
@@ -15,6 +15,7 @@
 package tempbuild
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -25,7 +26,7 @@ import (
 //
 // Instead of installing a program in a global location like GOBIN, you can use Build
 // to make a temporary/private copy of the program.
-func Build(packageSpec, tempFilePattern string) (string, error) {
+func Build(ctx context.Context, packageSpec, tempFilePattern string) (string, error) {
 	file, err := ioutil.TempFile("", tempFilePattern)
 	if err != nil {
 		return "", fmt.Errorf("failed ioutil.TempFile: %w", err)
@@ -34,7 +35,7 @@ func Build(packageSpec, tempFilePattern string) (string, error) {
 	path := file.Name()
 	file.Close()
 
-	buildCmd := exec.Command("go", "build", "-o", path, packageSpec)
+	buildCmd := exec.CommandContext(ctx, "go", "build", "-o", path, packageSpec)
 	buildOutput, err := buildCmd.CombinedOutput()
 	if err != nil {
 		os.Remove(path)

--- a/test_01_hello_test.go
+++ b/test_01_hello_test.go
@@ -15,7 +15,6 @@
 package docket_test
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -43,7 +42,7 @@ type HelloSuite struct {
 }
 
 func (s *HelloSuite) Test_FailsOutsideDocker() {
-	cmd := exec.CommandContext(context.Background(), "go", "test", "-v")
+	cmd := exec.Command("go", "test", "-v")
 	cmd.Args = append(cmd.Args, goTestCoverageArgs(s.T().Name())...)
 	cmd.Args = append(cmd.Args, goTestRaceDetectorArgs()...)
 	cmd.Dir = s.dir
@@ -56,7 +55,7 @@ func (s *HelloSuite) Test_FailsOutsideDocker() {
 }
 
 func (s *HelloSuite) Test_SucceedsInsideDocker() {
-	cmd := exec.CommandContext(context.Background(), "go", "test", "-v")
+	cmd := exec.Command("go", "test", "-v")
 	cmd.Args = append(cmd.Args, goTestCoverageArgs(s.T().Name())...)
 	cmd.Args = append(cmd.Args, goTestRaceDetectorArgs()...)
 	cmd.Dir = s.dir

--- a/test_02_ping-redis_test.go
+++ b/test_02_ping-redis_test.go
@@ -15,7 +15,6 @@
 package docket_test
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -43,17 +42,17 @@ type PingRedisSuite struct {
 }
 
 func (s *PingRedisSuite) Test_DebugMode() {
-	s.testMode(context.Background(), "debug")
+	s.testMode("debug")
 }
 
 func (s *PingRedisSuite) Test_FullMode() {
-	s.testMode(context.Background(), "full")
+	s.testMode("full")
 }
 
 //------------------------------------------------------------------------------
 
-func (s *PingRedisSuite) testMode(ctx context.Context, mode string) {
-	cmd := exec.CommandContext(ctx, "go", "test", "-v")
+func (s *PingRedisSuite) testMode(mode string) {
+	cmd := exec.Command("go", "test", "-v")
 	cmd.Args = append(cmd.Args, goTestCoverageArgs(s.T().Name())...)
 	cmd.Args = append(cmd.Args, goTestRaceDetectorArgs()...)
 	cmd.Dir = s.dir

--- a/test_03_redispinger-service_test.go
+++ b/test_03_redispinger-service_test.go
@@ -55,7 +55,7 @@ func (s *RedisPingerSuite) Test_DebugMode() {
 	defer os.Remove(dktPath)
 
 	dkt := func(arg ...string) []byte {
-		return s.runDkt(ctx, dktPath, append([]string{"--mode=debug"}, arg...)...)
+		return s.runDkt(dktPath, append([]string{"--mode=debug"}, arg...)...)
 	}
 
 	// Bring up docker compose app and discover redis's port
@@ -69,7 +69,7 @@ func (s *RedisPingerSuite) Test_DebugMode() {
 
 	// Start a pinger service and discover its listener port
 
-	pingerCmd, pingerPort := s.startPinger(ctx)
+	pingerCmd, pingerPort := s.startPinger()
 	defer func() {
 		s.Require().NoError(pingerCmd.Process.Kill())
 		s.Error(pingerCmd.Wait()) // since we killed the process, Wait will return an error
@@ -77,7 +77,7 @@ func (s *RedisPingerSuite) Test_DebugMode() {
 
 	// Run go test with REDISPINGER_URL set properly
 
-	testCmd := exec.CommandContext(ctx, "go", "test", "-v")
+	testCmd := exec.Command("go", "test", "-v")
 	testCmd.Args = append(testCmd.Args, goTestCoverageArgs(s.T().Name())...)
 	testCmd.Args = append(testCmd.Args, goTestRaceDetectorArgs()...)
 	testCmd.Dir = s.dir
@@ -95,7 +95,7 @@ func (s *RedisPingerSuite) Test_DebugMode() {
 }
 
 func (s *RedisPingerSuite) Test_FullMode() {
-	cmd := exec.CommandContext(context.Background(), "go", "test", "-v")
+	cmd := exec.Command("go", "test", "-v")
 	cmd.Args = append(cmd.Args, goTestCoverageArgs(s.T().Name())...)
 	cmd.Args = append(cmd.Args, goTestRaceDetectorArgs()...)
 	cmd.Dir = s.dir
@@ -110,8 +110,8 @@ func (s *RedisPingerSuite) Test_FullMode() {
 
 //------------------------------------------------------------------------------
 
-func (s *RedisPingerSuite) runDkt(ctx context.Context, exePath string, arg ...string) []byte {
-	cmd := exec.CommandContext(ctx, exePath, arg...)
+func (s *RedisPingerSuite) runDkt(exePath string, arg ...string) []byte {
+	cmd := exec.Command(exePath, arg...)
 	cmd.Dir = s.dir
 
 	out, err := cmd.Output()
@@ -128,8 +128,8 @@ func (s *RedisPingerSuite) runDkt(ctx context.Context, exePath string, arg ...st
 	return out
 }
 
-func (s *RedisPingerSuite) startPinger(ctx context.Context) (cmd *exec.Cmd, port string) {
-	cmd = exec.CommandContext(ctx, "go", "run", ".")
+func (s *RedisPingerSuite) startPinger() (cmd *exec.Cmd, port string) {
+	cmd = exec.Command("go", "run", ".")
 	cmd.Dir = s.dir
 
 	stdout, err := cmd.StdoutPipe()

--- a/test_03_redispinger-service_test.go
+++ b/test_03_redispinger-service_test.go
@@ -50,7 +50,7 @@ type RedisPingerSuite struct {
 func (s *RedisPingerSuite) Test_DebugMode() {
 	ctx := context.Background()
 
-	dktPath, err := tempbuild.Build("github.com/bloomberg/docket/dkt", "dkt.")
+	dktPath, err := tempbuild.Build(ctx, "github.com/bloomberg/docket/dkt", "dkt.")
 	s.Require().NoError(err)
 	defer os.Remove(dktPath)
 

--- a/test_99_testify-suite_test.go
+++ b/test_99_testify-suite_test.go
@@ -17,7 +17,6 @@ package docket_test
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -46,11 +45,11 @@ type TestifySuiteSuite struct {
 }
 
 func (s *TestifySuiteSuite) Test_All() {
-	s.runGoTest(context.Background())
+	s.runGoTest()
 }
 
 func (s *TestifySuiteSuite) Test_SuiteLevel_OnlySubtestA() {
-	output, sawA, sawB, sawC, sawOthers := s.testSubtestA(context.Background(), true)
+	output, sawA, sawB, sawC, sawOthers := s.testSubtestA(true)
 
 	s.Equalf(true, sawA, "should have seen TestA, output: %s", output)
 	s.Equalf(false, sawB, "should not have seen TestB, output: %s", output)
@@ -59,7 +58,7 @@ func (s *TestifySuiteSuite) Test_SuiteLevel_OnlySubtestA() {
 }
 
 func (s *TestifySuiteSuite) Test_SuiteLevel_EverythingButSubtestA() {
-	output, sawA, sawB, sawC, sawOthers := s.testSubtestA(context.Background(), false)
+	output, sawA, sawB, sawC, sawOthers := s.testSubtestA(false)
 
 	s.Equalf(false, sawA, "should not have seen TestA, output: %s", output)
 	s.Equalf(true, sawB, "should have seen TestB, output: %s", output)
@@ -69,8 +68,8 @@ func (s *TestifySuiteSuite) Test_SuiteLevel_EverythingButSubtestA() {
 
 //------------------------------------------------------------------------------
 
-func (s *TestifySuiteSuite) runGoTest(ctx context.Context, arg ...string) []byte {
-	cmd := exec.CommandContext(ctx, "go", "test", "-v")
+func (s *TestifySuiteSuite) runGoTest(arg ...string) []byte {
+	cmd := exec.Command("go", "test", "-v")
 	cmd.Args = append(cmd.Args, goTestCoverageArgs(s.T().Name())...)
 	cmd.Args = append(cmd.Args, goTestRaceDetectorArgs()...)
 	cmd.Args = append(cmd.Args, arg...)
@@ -87,7 +86,7 @@ func (s *TestifySuiteSuite) runGoTest(ctx context.Context, arg ...string) []byte
 }
 
 // Helper routine that either runs ONLY subtestA or everything EXCEPT subtestA.
-func (s *TestifySuiteSuite) testSubtestA(ctx context.Context, includeA bool) (
+func (s *TestifySuiteSuite) testSubtestA(includeA bool) (
 	output []byte, sawA, sawB, sawC, sawOthers bool,
 ) {
 	negation := ""
@@ -96,7 +95,7 @@ func (s *TestifySuiteSuite) testSubtestA(ctx context.Context, includeA bool) (
 	}
 	runArg := fmt.Sprintf("-run=DocketRunAtSuiteLevel/Test[%sA]", negation)
 
-	output = s.runGoTest(ctx, runArg)
+	output = s.runGoTest(runArg)
 
 	ranTest := regexp.MustCompile(`^=== RUN   Test.+/Test[A-Z]$`)
 


### PR DESCRIPTION
- Pass `context` into `internal/tempbuild.Build`
- Use `exec.Command` in tests